### PR TITLE
Bug fix: `torch_sparse.transpose` outputs are coalesced

### DIFF
--- a/example/gsat.py
+++ b/example/gsat.py
@@ -41,7 +41,7 @@ class GSAT(nn.Module):
         if self.learn_edge_att:
             if is_undirected(data.edge_index):
                 nodesize = data.x.shape[0]
-                edge_att = (att + transpose(data.edge_index, att, nodesize, nodesize)[1]) / 2
+                edge_att = (att + transpose(data.edge_index, att, nodesize, nodesize, coalesced=False)[1]) / 2
             else:
                 edge_att = att
         else:


### PR DESCRIPTION
`torch_sparse.transpose` would coalesce outputs by default and mess up results when input `edge_index` is not sorted. This issue does not affect any reported results, but it may cause problems potentially. Setting `coalesced=False` resolves the issue. 