### PR TITLE
Add `reorder_like` to speed up the averaging of edge weights for undirected graphs

### DIFF
--- a/example/gsat.py
+++ b/example/gsat.py
@@ -4,8 +4,9 @@ sys.path.append('../src')
 import scipy
 import torch
 import torch.nn as nn
+from torch_sparse import transpose
 from torch_geometric.utils import is_undirected
-from utils import MLP
+from utils import MLP, reorder_like
 
 
 class GSAT(nn.Module):
@@ -40,9 +41,9 @@ class GSAT(nn.Module):
 
         if self.learn_edge_att:
             if is_undirected(data.edge_index):
-                nodesize = data.x.shape[0]
-                sci_csr = scipy.sparse.csr_matrix((torch.arange(att.shape[0]), (data.edge_index[0].cpu(), data.edge_index[1].cpu())), (nodesize, nodesize))
-                edge_att = (att + att[sci_csr[data.edge_index[1].tolist(), data.edge_index[0].tolist()].A1]) / 2
+                trans_idx, trans_val = transpose(data.edge_index, att, None, None, coalesced=False)
+                trans_val_perm = reorder_like(trans_idx, data.edge_index, trans_val)
+                edge_att = (att + trans_val_perm) / 2
             else:
                 edge_att = att
         else:

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -5,7 +5,7 @@ import networkx as nx
 from rdkit import Chem
 import matplotlib.pyplot as plt
 from torch_geometric.data import Data
-from torch_geometric.utils import to_networkx
+from torch_geometric.utils import to_networkx, sort_edge_index
 from torch.utils.tensorboard import SummaryWriter
 from torch.utils.tensorboard.summary import hparams
 
@@ -14,6 +14,15 @@ init_metric_dict = {'metric/best_clf_epoch': 0, 'metric/best_clf_valid_loss': 0,
                     'metric/best_clf_train': 0, 'metric/best_clf_valid': 0, 'metric/best_clf_test': 0,
                     'metric/best_x_roc_train': 0, 'metric/best_x_roc_valid': 0, 'metric/best_x_roc_test': 0,
                     'metric/best_x_precision_train': 0, 'metric/best_x_precision_valid': 0, 'metric/best_x_precision_test': 0}
+
+
+def reorder_like(from_edge_index, to_edge_index, values):
+    from_edge_index, values = sort_edge_index(from_edge_index, values)
+    ranking_score = to_edge_index[0] * (to_edge_index.max()+1) + to_edge_index[1]
+    ranking = ranking_score.argsort().argsort()
+    if not (from_edge_index[:, ranking] == to_edge_index).all():
+        raise ValueError("Edges in from_edge_index and to_edge_index are different, impossible to match both.")
+    return values[ranking]
 
 
 def process_data(data, use_edge_attr):


### PR DESCRIPTION
As kindly pointed out by @simoons95 in https://github.com/Graph-COM/GSAT/issues/5#issuecomment-1318688708, `reorder_like` addresses https://github.com/Graph-COM/GSAT/issues/5 and is much faster.